### PR TITLE
Fix the pool loading for APE/ETH

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -65,7 +65,14 @@ function AddLiquidity({ tab }: Props) {
   }, [tab]);
 
   useEffect(() => {
-    if (!chainId || !tokens || !baseTokenSymbol || !quoteTokenSymbol || !fee) {
+    if (
+      !chainId ||
+      !tokens ||
+      !tokens.length ||
+      !baseTokenSymbol ||
+      !quoteTokenSymbol ||
+      !fee
+    ) {
       return;
     }
 
@@ -75,7 +82,7 @@ function AddLiquidity({ tab }: Props) {
     ]);
 
     // invalid tokens
-    if (matches.length < 2) {
+    if (matches.length !== 2) {
       return;
     }
 

--- a/src/pages/AddLiquidity/utils.tsx
+++ b/src/pages/AddLiquidity/utils.tsx
@@ -185,17 +185,23 @@ export function findTokens(
   tokens: TokenListItem[],
   symbols: string[]
 ) {
-  const symbolsFormatted = symbols.map((symbol) => {
-    const s = symbol.toUpperCase();
+  const symbolsFormatted = symbols.map((sym) => {
+    const s = sym.toUpperCase();
     if (s === "ETH") {
       return "WETH";
     }
     return s;
   });
-  const matches = tokens.filter(
-    (token: TokenListItem) =>
-      token.chainId === chainId && symbolsFormatted.includes(token.symbol)
-  );
+
+  let matches = [];
+  symbolsFormatted.forEach((sym) => {
+    const matched = tokens.find((token: TokenListItem) => {
+      return token.chainId === chainId && token.symbol === sym;
+    });
+    if (matched) {
+      matches.push(matched);
+    }
+  });
 
   // Optimism WETH
   if (chainId === 10 && symbolsFormatted.includes("WETH")) {


### PR DESCRIPTION
Noticed APE/ETH pool wasn't loading when adding liquidity due to how I was selecting tokens based on symbols (APE matched to 3 different tokens 😱 ). Fixed `findTokens` to only select the first match (given Coingecko token list is sorted by market values, unlikely to be matched with a bogus token).