### PR TITLE
increase precision for 0.01% fee tier pools

### DIFF
--- a/src/pages/AddLiquidity/NewPosition.tsx
+++ b/src/pages/AddLiquidity/NewPosition.tsx
@@ -329,7 +329,7 @@ function NewPosition({
       tickToPrice(quoteToken, baseToken, tickCurrent).toSignificant(16)
     );
 
-    return formatInput(price);
+    return formatInput(price, false, pool.tickSpacing === 1 ? 8 : 4);
   }, [pool, baseToken, quoteToken]);
 
   if (!pool || !baseToken || !quoteToken) {

--- a/src/pages/AddLiquidity/RangeData.tsx
+++ b/src/pages/AddLiquidity/RangeData.tsx
@@ -78,6 +78,14 @@ function RangeData({
     return [convertToPrice(tickLower), convertToPrice(tickUpper)];
   }, [tickLower, tickUpper, baseToken, quoteToken]);
 
+  const domain = useMemo(() => {
+    if (!pool) {
+      return [0, 0];
+    }
+    const multiplier = (pool.tickSpacing / 10000) * pool.tickSpacing;
+    return [minPrice - minPrice * multiplier, maxPrice + maxPrice * multiplier];
+  }, [pool, minPrice, maxPrice]);
+
   const handleSelect = (item: number) => {
     setMenuOpened(false);
     setChart(item);
@@ -111,18 +119,11 @@ function RangeData({
               margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
             >
               <XAxis dataKey="date" />
-              <YAxis
-                width={100}
-                mirror={true}
-                domain={[
-                  priceLower - priceLower * 0.25,
-                  priceUpper + priceUpper * 0.25,
-                ]}
-              />
+              <YAxis width={100} mirror={true} domain={domain} />
               <Tooltip />
               <Legend />
-              <ReferenceLine y={priceLower} stroke="#ff6361" />
-              <ReferenceLine y={priceUpper} stroke="#ff6361" />
+              <ReferenceLine y={priceLower} stroke="#9a3b38" strokeWidth={1} />
+              <ReferenceLine y={priceUpper} stroke="#9a3b38" strokeWidth={1} />
               <Brush dataKey="date" height={30} stroke="#3390d6" />
               <Line
                 type="monotone"
@@ -185,8 +186,6 @@ function RangeData({
             <YAxis hide={true} />
             <Tooltip />
             <Legend />
-            <ReferenceLine x={priceLower} stroke="#ff6361" />
-            <ReferenceLine x={priceUpper} stroke="#ff6361" />
             <Brush dataKey="price" height={30} stroke="#3390d6" />
             <Area
               dataKey="liquidity"
@@ -194,6 +193,8 @@ function RangeData({
               fillOpacity={0.9}
               stroke="#3390d6"
             />
+            <ReferenceLine x={priceLower} stroke="#9a3b38" strokeWidth={2} />
+            <ReferenceLine x={priceUpper} stroke="#9a3b38" strokeWidth={2} />
           </AreaChart>
         </ResponsiveContainer>
       )}

--- a/src/pages/AddLiquidity/RangeInput.tsx
+++ b/src/pages/AddLiquidity/RangeInput.tsx
@@ -50,8 +50,8 @@ function RangeInput({
       tickToPrice(token1, token0, tick).toSignificant(16)
     );
 
-    setInput(formatInput(price));
-  }, [token0, token1, tick]);
+    setInput(formatInput(price, false, tickSpacing === 1 ? 8 : 4));
+  }, [token0, token1, tick, tickSpacing]);
 
   const handleInput = (ev: { target: any }) => {
     const { value } = ev.target;

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -16,15 +16,19 @@ export function formatCurrency(num: number, symbol?: string) {
   });
 }
 
-export function formatInput(input: number, rounding: boolean = true) {
+export function formatInput(
+  input: number,
+  rounding: boolean = true,
+  mantissa: number = 4
+) {
   if (isNaN(input)) {
     return "0";
   }
 
   return numbro(input).format({
-    mantissa: input > 0.01 ? 4 : 8,
+    mantissa: input > 0.01 ? mantissa : 8,
     optionalMantissa: true,
-    trimMantissa: true,
+    trimMantissa: mantissa === 4,
     roundingFunction: rounding ? Math.floor : (val: number) => val,
   });
 }


### PR DESCRIPTION
Previously, when adding liquidity, it wasn't possible to set precise ranges for 0.01% fee tiers. This PR fixes it by increasing the range preicision.